### PR TITLE
Fix empty HTML tests and the --dry-run option

### DIFF
--- a/smoketest/directives.py
+++ b/smoketest/directives.py
@@ -77,6 +77,8 @@ class _DummyResponse(object):
     def __init__(self):
         self.elapsed = datetime.timedelta(milliseconds=1)
         self.status_code = 200
+        self.is_redirect = False
+        self.history = ()
 
 
 def get_session(elem, options):

--- a/smoketest/tests.py
+++ b/smoketest/tests.py
@@ -52,7 +52,7 @@ def get_tree(response):
     except KeyError:
         try:
             tree = lxml.html.fromstring(response.text)
-        except lxml.etree.XMLSyntaxError:
+        except (lxml.etree.XMLSyntaxError, lxml.etree.ParserError):
             tree = None
         _TREE_CACHE[response] = tree
         return tree


### PR DESCRIPTION
It appears that newer versions of lxml broke the tests and the --dry-run option didn't work for me.

Feel free to create a new target branch or similar for merging.