### PR TITLE
utils: Extend level_transform to support custom positions

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -16,6 +16,26 @@ run smoketest with a ``--level=dev`` argument, it will append "-dev" to the
 first part of the domain name of every URL it tests: "www.usnews.com" becomes
 "www-dev.usnews.com".
 
+You can override that method of specifying levels by including the
+``level_token`` token in URLs. The token defaults to the string:
+
+.. code-block:: yaml
+
+    level_token: '{LEVEL}'
+
+For example:
+
+.. code-block:: yaml
+
+    - https://{LEVEL}.usnews.com/opinion
+    - https://www-{LEVEL}.usnews.com/opinion
+
+For the first ``live`` will test https://usnews.com/opinion while for a level
+such as ``stag``, it will test https://stag.usnews.com/opinion. The second will
+be https://www.usnews.com/opinion and https://www-stag.usnews.com/opinion,
+respectively. It tries to intelligently remove extra ".", "-", and "/" as
+needed if the level would be omitted in the case of ``live``.
+
 Note that the default level is ``live``, so running smoketest without a level
 argument is equivalent to running it with ``--level=live``.
 

--- a/smoketest/settings.py
+++ b/smoketest/settings.py
@@ -59,3 +59,7 @@ def get_ca_path():
 def get_default_request_timeout():
     # Use 30.0 seconds as a fallback
     return _get_settings().get('timeout', 30.0)
+
+
+def get_level_token():
+    return _get_settings().get('level_token', '{LEVEL}')

--- a/smoketest/utils.py
+++ b/smoketest/utils.py
@@ -41,26 +41,29 @@ def transform_url(url, scheme=None, port=None, level=None, cachebust=None):
 
 
 def level_transform(parts, level):
-    """Transform the first subdomain according to our habits.
+    """Transform the first subdomain according to our habits, normally.
     www.usnews.com => www-level.usnews.com
-    """
-    LEVEL_VAR = get_level_token()
 
-    if LEVEL_VAR and LEVEL_VAR in parts[1] + parts[2]:
+    Can also be used for a more general replacements, see the docs:
+    {LEVEL}www.usnews.com => level-www.usnews.com
+    """
+    level_token = get_level_token()
+
+    if level_token and level_token in parts[1] + parts[2]:
         host, path = parts[1], parts[2]
         if level == 'live':
             level = ''
 
         if host:
-            host = host.replace(LEVEL_VAR, level)
+            host = host.replace(level_token, level)
             host = host.replace('..', '.').replace('-.', '.')
             if host[0] in ('-', '.'):
                 host = host[1:]
         if path:
-            if level == '' and LEVEL_VAR+'/' in path:
-                path = path.replace(LEVEL_VAR+'/', level)
+            if level == '' and level_token + '/' in path:
+                path = path.replace(level_token + '/', level)
             else:
-                path = path.replace(LEVEL_VAR, level)
+                path = path.replace(level_token, level)
         parts[1] = host
         parts[2] = path
     elif level == 'live':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,7 +75,7 @@ class TestTransformUrlBasedOnOptions(unittest.TestCase):
         transformed = transform_url_based_on_options(url, options)
         self.assertEqual(transformed, 'http://www-stag.usnews.com')
 
-    def test_custom_evel(self):
+    def test_custom_level(self):
         from smoketest.utils import transform_url_based_on_options
         from collections import namedtuple
         Options = namedtuple('Options', ('scheme', 'level', 'port', 'cachebust'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,6 +75,50 @@ class TestTransformUrlBasedOnOptions(unittest.TestCase):
         transformed = transform_url_based_on_options(url, options)
         self.assertEqual(transformed, 'http://www-stag.usnews.com')
 
+    def test_custom_evel(self):
+        from smoketest.utils import transform_url_based_on_options
+        from collections import namedtuple
+        Options = namedtuple('Options', ('scheme', 'level', 'port', 'cachebust'))
+        url = 'http://www-{LEVEL}.usnews.com'
+
+        options = Options(None, 'live', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://www.usnews.com')
+
+        options = Options(None, 'stag', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://www-stag.usnews.com')
+
+        url = 'http://{LEVEL}.usnews.com'
+
+        options = Options(None, 'live', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://usnews.com')
+
+        options = Options(None, 'stag', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://stag.usnews.com')
+
+        url = 'http://{LEVEL}-www.usnews.com'
+
+        options = Options(None, 'live', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://www.usnews.com')
+
+        options = Options(None, 'stag', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://stag-www.usnews.com')
+
+        url = 'http://www.usnews.com/{LEVEL}/'
+
+        options = Options(None, 'live', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://www.usnews.com/')
+
+        options = Options(None, 'stag', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://www.usnews.com/stag/')
+
     def test_port(self):
         from smoketest.utils import transform_url_based_on_options
         from collections import namedtuple


### PR DESCRIPTION
Replace the level in custom locations in URLs if you include the proper
token that matches the `level_token` token and do not do the normal
level URL munging for those directives.

Implements #1