### PR TITLE
Support all text-matching methods for HTTP response header tests.

### DIFF
--- a/smoketest/tests.py
+++ b/smoketest/tests.py
@@ -640,7 +640,6 @@ class HeaderTestResult(TestResult):
         )
 
     def __nonzero__(self):
-        desired_value = self.test.value
         actual_value = self._get_header_value_from_response()
         match = self.test.text_matching_method(actual_value)
         return bool(match)

--- a/smoketest/tests.py
+++ b/smoketest/tests.py
@@ -265,12 +265,10 @@ def get_header_tests(elem, options):
                     text_matching_methodname,
                     test[text_matching_methodname],
                 )
-                value = test.get(text_matching_methodname)
                 header_tests.append(
                     HeaderTest(
                         header,
                         text_matching_method,
-                        value,
                     )
                 )
 
@@ -767,10 +765,9 @@ class JSONSchemaTest(AbstractTest):
 
 class HeaderTest(AbstractTest):
 
-    def __init__(self, header, text_matching_method, value):
+    def __init__(self, header, text_matching_method):
         self.header = header
         self.text_matching_method = text_matching_method
-        self.value = value
 
     @property
     def description(self):

--- a/smoketest/tests.py
+++ b/smoketest/tests.py
@@ -256,9 +256,26 @@ def get_json_schema_tests(elem, options):
 def get_header_tests(elem, options):
     all_header_tests = []
     for test in elem.get('headers', []):
+        header_tests = []
         header = test['header']
-        value = test['equals']
-        all_header_tests.append(HeaderTest(header, value))
+
+        for text_matching_methodname in TextMatchingMethod.available_methods:
+            if text_matching_methodname in test:
+                text_matching_method = TextMatchingMethod(
+                    text_matching_methodname,
+                    test[text_matching_methodname],
+                )
+                value = test.get(text_matching_methodname)
+                header_tests.append(
+                    HeaderTest(
+                        header,
+                        text_matching_method,
+                        value,
+                    )
+                )
+
+        all_header_tests.extend(header_tests)
+
     return all_header_tests
 
 
@@ -625,7 +642,8 @@ class HeaderTestResult(TestResult):
     def __nonzero__(self):
         desired_value = self.test.value
         actual_value = self._get_header_value_from_response()
-        return desired_value == actual_value
+        match = self.test.text_matching_method(actual_value)
+        return bool(match)
 
     def _get_header_value_from_response(self):
         return self.response.headers.get(self.test.header)
@@ -750,10 +768,14 @@ class JSONSchemaTest(AbstractTest):
 
 class HeaderTest(AbstractTest):
 
-    def __init__(self, header, value):
+    def __init__(self, header, text_matching_method, value):
         self.header = header
+        self.text_matching_method = text_matching_method
         self.value = value
 
     @property
     def description(self):
-        return u'{0} header equals {1}'.format(self.header, self.value)
+        return u'{0} header {1}'.format(
+            self.header,
+            self.text_matching_method.description,
+        )

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -390,7 +390,6 @@ class TestTestResults(unittest.TestCase):
         header_test = HeaderTest(
             'X-Some-Header',
             TextMatchingMethod('equals', 'ello'),
-            'hi',
         )
         response = Mock()
         response.headers = {
@@ -634,7 +633,6 @@ class TestParsers(unittest.TestCase):
         header_tests = get_header_tests(elem, options)
         self.assertEqual(1, len(header_tests))
         self.assertEqual('X-Some-Header', header_tests[0].header)
-        self.assertEqual('hi', header_tests[0].value)
 
 
 class TestSelectFromJsonifiable(unittest.TestCase):

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -385,8 +385,13 @@ class TestTestResults(unittest.TestCase):
     def test_header_test(self):
         from smoketest.tests import (
             HeaderTest,
+            TextMatchingMethod,
         )
-        header_test = HeaderTest('X-Some-Header', 'hi')
+        header_test = HeaderTest(
+            'X-Some-Header',
+            TextMatchingMethod('equals', 'ello'),
+            'hi',
+        )
         response = Mock()
         response.headers = {
             'X-Some-Header': 'bye',


### PR DESCRIPTION
Previously only "equals" was supported. Now other text-matching
methods such as "contains" and "startswith" will work.

Fixes #26.