### PR TITLE
Gracefully handle missing response headers in `HeaderTestResult`

### DIFF
--- a/smoketest/tests.py
+++ b/smoketest/tests.py
@@ -634,13 +634,18 @@ class HeaderTestResult(TestResult):
 
     @property
     def description(self):
-        return u'{0} header was {1}'.format(
-            self.test.header,
-            self._get_header_value_from_response(),
-        )
+        header = self.test.header
+        header_value = self._get_header_value_from_response()
+        if header_value is None:
+            description = u'{0} header was not present'.format(header)
+        else:
+            description = u'{0} header was {1}'.format(header, header_value)
+        return description
 
     def __nonzero__(self):
         actual_value = self._get_header_value_from_response()
+        if actual_value is None:
+            return False
         match = self.test.text_matching_method(actual_value)
         return bool(match)
 

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -402,6 +402,24 @@ class TestTestResults(unittest.TestCase):
             result.description,
         )
 
+    def test_header_test_missing_response_header(self):
+        from smoketest.tests import (
+            HeaderTest,
+            TextMatchingMethod,
+        )
+        header_test = HeaderTest(
+            'X-Some-Header',
+            TextMatchingMethod('equals', 'bye'),
+        )
+        response = Mock()
+        response.headers = {}
+        result = header_test.get_result(response)
+        self.assertFalse(result)
+        self.assertEqual(
+            'X-Some-Header header was not present',
+            result.description,
+        )
+
 
 class TestTextMatchingMethod(unittest.TestCase):
     """Tests for the class TextMatchingMethod


### PR DESCRIPTION
Fixes #41