### PR TITLE
Replace 0xa0 when normalizing whitespace

### DIFF
--- a/smoketest/tests.py
+++ b/smoketest/tests.py
@@ -293,13 +293,17 @@ class TextMatchingMethod(object):
         self.methodname = methodname
         if text_to_match:
             # Apply HTML whitespace transform
-            text_to_match = re.sub('[' + string.whitespace + ']+', ' ', text_to_match.strip())
+            text_to_match = re.sub(
+                '[' + string.whitespace + u'\xa0' + ']+', ' ',
+                text_to_match.strip())
         self.text_to_match = text_to_match
 
     def __call__(self, text_to_test):
         if text_to_test:
             # Apply HTML whitespace transform
-            text_to_test = re.sub('[' + string.whitespace + ']+', ' ', text_to_test.strip())
+            text_to_test = re.sub(
+                '[' + string.whitespace + u'\xa0' + ']+', ' ',
+                text_to_test.strip())
         if self.methodname == 'regex':
             match = re.search(self.text_to_match, text_to_test)
         elif self.methodname == 'startswith':
@@ -419,7 +423,9 @@ class HTMLTestResult(TestResult):
         if string_to_test:
             # We never care about the whitespace around text in HTML, and it
             # causes false positives, so remove it.
-            string_to_test = string_to_test.strip()
+            string_to_test = re.sub(
+                '[' + string.whitespace + u'\xa0' + ']+', ' ',
+                string_to_test.strip())
 
         return string_to_test
 

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -470,6 +470,20 @@ class TestTextMatchingMethod(unittest.TestCase):
         self.assertTrue(text_matching_method('a^hello$b'))
         self.assertFalse(text_matching_method('hello'))
 
+    def test_collapse_whitespace(self):
+        """Tests handling of whitespace characters.
+
+        ASCII whitespace characters and non-breaking spaces (0xa0)
+        should all be collapsed into regular spaces.
+        """
+        from smoketest.tests import TextMatchingMethod
+        text_matching_method = TextMatchingMethod(
+            'equals',
+            '^hello hello hello hello$',
+        )
+        self.assertTrue(text_matching_method(
+            u'^hello\t\thello\n\n\nhello\xa0hello$'))
+
 
 class TestParsers(unittest.TestCase):
     """Tests for the parser functions


### PR DESCRIPTION
When running string-comparison tests, all whitespace characters in both
the expectation string and the string being tested are collapsed into
normal ASCII spaces. This commit applies the same behavior to
non-breaking spaces, preventing spurious errors.