### PR TITLE
Handle non-ascii html attributes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ config = {
     ],
     'install_requires': [
         'PyYAML',
+        'bs4',
         'cssselect',
         'jsonschema',
         'lxml',

--- a/smoketest/tests.py
+++ b/smoketest/tests.py
@@ -13,7 +13,7 @@ from xml.etree import ElementTree
 import jsonschema
 import lxml
 from lxml.etree import XMLSyntaxError
-import lxml.html
+import lxml.html.soupparser
 from lxml.cssselect import CSSSelector
 
 from smoketest.utils import (
@@ -53,7 +53,7 @@ def get_tree(response):
         return _TREE_CACHE[response]
     except KeyError:
         try:
-            tree = lxml.html.fromstring(response.text)
+            tree = lxml.html.soupparser.fromstring(response.text)
         except (lxml.etree.XMLSyntaxError, lxml.etree.ParserError):
             tree = None
         _TREE_CACHE[response] = tree

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -9,6 +9,22 @@ from mock import (
 )
 
 
+class TestGetTree(unittest.TestCase):
+    """Tests for the get_tree function
+    """
+
+    def test_nonascii_attribute(self):
+        from smoketest.tests import get_tree
+        response = Mock()
+        response.text = u"""
+            <html \u2603 \u2604="yes">
+            </html>
+        """
+        tree = get_tree(response)
+        self.assertIn(u'\u2603', tree.attrib)
+        self.assertEqual('yes', tree.attrib[u'\u2604'])
+
+
 class TestTestResults(unittest.TestCase):
     """Tests for the TestResult classes
     """


### PR DESCRIPTION
This is for https://github.com/usnews/smoketest/issues/38.

This fixes an issue where non-ascii HTML attributes weren't being picked up when parsing HTML responses, which prevented us from being able to test them.

The fix is to require BeautifulSoup and use its parser instead of lxml's default HTML parser.

Here is a snippet of code that demonstrates the issue and the fix:

```
# -*- coding: utf-8 -*-

import lxml.html
import lxml.html.soupparser

html = u'<html ⚡></html>'

tree1 = lxml.html.fromstring(html)
print(tree1.attrib)  # output: {}

tree2 = lxml.html.soupparser.fromstring(html)
print(tree2.attrib)  # output: {u'\u26a1': ''}
```