### PR TITLE
Support an empty string for level

### DIFF
--- a/smoketest/utils.py
+++ b/smoketest/utils.py
@@ -31,7 +31,7 @@ def transform_url(url, scheme=None, port=None, level=None, cachebust=None):
         parts[0] = scheme
     if port:
         parts = port_transform(parts, port)
-    if level:
+    if level is not None:
         parts = level_transform(parts, level)
     if cachebust:
         parts = cachebust_transform(parts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,6 +119,16 @@ class TestTransformUrlBasedOnOptions(unittest.TestCase):
         transformed = transform_url_based_on_options(url, options)
         self.assertEqual(transformed, 'http://www.usnews.com/stag/')
 
+        url = 'http://www.usnews{LEVEL}.com'
+
+        options = Options(None, '-staging', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://www.usnews-staging.com')
+
+        options = Options(None, '', None, False)
+        transformed = transform_url_based_on_options(url, options)
+        self.assertEqual(transformed, 'http://www.usnews.com')
+
     def test_port(self):
         from smoketest.utils import transform_url_based_on_options
         from collections import namedtuple


### PR DESCRIPTION
Allow specifying an empty string for the level parameter. Without this
change, specifying `--level ""` results in `{LEVEL}` not being replaced
in urls.